### PR TITLE
Remove close/reopen logic for file handle and fix Ecc crash on empty

### DIFF
--- a/Sources/Ecc/Main.cpp
+++ b/Sources/Ecc/Main.cpp
@@ -239,7 +239,7 @@ enum ESStatus
 };
 
 /* Determine whether or not our target ES file is indeed valid input. */
-ESStatus GetESStatus(char *filename)
+ESStatus GetESStatus()
 {
     ESStatus result = ESStatus::Empty;
 
@@ -249,7 +249,7 @@ ESStatus GetESStatus(char *filename)
     char* temporaryBuffer = (char*)malloc(length);
     fseek(_fInput, 0, SEEK_SET);
     fread(temporaryBuffer, length, 1, _fInput);
-    fclose(_fInput);
+    fseek(_fInput, 0, SEEK_SET);
 
     // Loop through each line
     char* currentSequence = strtok(temporaryBuffer, "\n");
@@ -315,17 +315,10 @@ ESStatus GetESStatus(char *filename)
                     result = ESStatus::Good;
 
             free(temporaryBuffer);
-            if (result == ESStatus::Good)
-                _fInput = FOpen(filename, "r");
-
             return result;
         }
     }
     while(currentSequence = strtok(NULL, "\n"));
-
-    free(temporaryBuffer);
-    if (result == ESStatus::Good)
-        _fInput = FOpen(filename, "r");
 
     return result;
 }
@@ -388,7 +381,7 @@ int main(int argc, char *argv[])
   _fInput = FOpen(argv[1], "r");
 
   // Make sure we're loading a valid ES file
-  ESStatus status = GetESStatus(argv[1]);
+  ESStatus status = GetESStatus();
 
   switch (status)
   {

--- a/Sources/Ecc/Main.cpp
+++ b/Sources/Ecc/Main.cpp
@@ -246,6 +246,11 @@ ESStatus GetESStatus()
     // Read a temporary buffer of the entire file contents
     fseek(_fInput, 0, SEEK_END);
     size_t length = ftell(_fInput);
+
+    // Hard-stop on Empty out of paranoia
+    if (length == 0)
+        return result;
+
     char* temporaryBuffer = (char*)malloc(length);
     fseek(_fInput, 0, SEEK_SET);
     fread(temporaryBuffer, length, 1, _fInput);

--- a/Sources/Ecc/Main.cpp
+++ b/Sources/Ecc/Main.cpp
@@ -391,9 +391,15 @@ int main(int argc, char *argv[])
   switch (status)
   {
       case ESStatus::Empty:
+      {
+          fclose(_fInput);
           return EXIT_SUCCESS;
+      }
       case ESStatus::Error:
+      {
+          fclose(_fInput);
           return EXIT_FAILURE;
+      }
   }
 
   //printf("%s\n", argv[1]);

--- a/Sources/Ecc/Main.cpp
+++ b/Sources/Ecc/Main.cpp
@@ -252,6 +252,10 @@ ESStatus GetESStatus()
         return result;
 
     char* temporaryBuffer = (char*)malloc(length);
+
+    if (!temporaryBuffer)
+        return ESStatus::Error;
+
     fseek(_fInput, 0, SEEK_SET);
     fread(temporaryBuffer, length, 1, _fInput);
     fseek(_fInput, 0, SEEK_SET);
@@ -398,6 +402,7 @@ int main(int argc, char *argv[])
       case ESStatus::Error:
       {
           fclose(_fInput);
+          printf("Ecc encountered an error during the es verification.\n");
           return EXIT_FAILURE;
       }
   }


### PR DESCRIPTION
Remove the funny close/reopen logic I introduced in the last PR https://github.com/Croteam-official/Serious-Engine/pull/12 I had merged in and fix crashes on 0 length files. Everything works on my Linux Mint AMD64 box here, though I don't know about Windows as per the last PR. 