### PR TITLE
Make Github recognize *.es files as C++

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.es linguist-language=C++


### PR DESCRIPTION
Adding an override as described on https://github.com/github/linguist