### PR TITLE
Simplify dealing with empty files in ECC

### DIFF
--- a/Sources/Ecc/Parser.y
+++ b/Sources/Ecc/Parser.y
@@ -243,7 +243,8 @@ void DeclareFeatureProperties(void)
  * Global structure of the source file.
  */
 program 
-  : c_int {
+  : /* empty file */ {}
+  | c_int {
     int iID = atoi($1.strString);
     if(iID>32767) {
       yyerror("Maximum allowed id for entity source file is 32767");


### PR DESCRIPTION
Why write a parser when you already have a perfectly good one already?  :)

This will just make (mostly) empty output files and report success, instead of failing, which I assume was the original intention in the code I'm removing here.