### PR TITLE
Fix broken angle calculation with negative epsilon numbers

### DIFF
--- a/Sources/Engine/Math/Functions.cpp
+++ b/Sources/Engine/Math/Functions.cpp
@@ -74,7 +74,7 @@ FLOAT Sin(ANGLE a)
 {
   double aWrapped = WrapAngle(a);
   double aIn90 = fmod(aWrapped, 90.0);
-  int iQuadrant = int(aWrapped/90.0);
+  int iQuadrant = int(aWrapped/90.0)%4;
   double fSin = adSinQuadrants[iQuadrant][0]*
     sin((aIn90+adSinQuadrants[iQuadrant][1])*PI/ANGLE_180);
   return FLOAT (fSin);
@@ -83,7 +83,7 @@ FLOAT Cos(ANGLE a)
 {
   double aWrapped = WrapAngle(a);
   double aIn90 = fmod(aWrapped, 90.0);
-  int iQuadrant = int(aWrapped/90.0);
+  int iQuadrant = int(aWrapped/90.0)%4;
   double fCos = adCosQuadrants[iQuadrant][0]*
     sin((aIn90+adCosQuadrants[iQuadrant][1])*PI/ANGLE_180);
   return FLOAT (fCos);


### PR DESCRIPTION
When calculating `Cos(-epsilon)` or `Sin(-epsilon)`, the result is incorrect.
The behavior is due to `WrapAngle(-epsilon)` returns exactly `360` degrees,
and `int iQuadrant = int(360.0/90.0); // iQuadrant == 4`, which is actually a quadrant with index `0`. So this operation must be wrapped around to produce stable results. Otherwise, index `4` is reading past the end of corresponding array.